### PR TITLE
Add statistics example page

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>RSNA CrowdQuant Stats</title>
+    <meta name="viewport" content="initial-scale=1">
+
+    <style type="text/css">
+      body {
+        font-family: Helvetica, Arial, sans-serif;
+        font-size: 14px;
+      }
+    </style>
+
+    <h1>Measurements Database Statistics</h1>
+    <p>This page demonstrates a live dashboard of the CrowdQuant database.  The contents will refresh every time a new measurement is added to the database.</p>
+    <p>
+    Below are a list of seriesUIDs with the count of the number of measurements.  Clicking on a series id will show a list of the measurements for that series.
+    </p>
+    <p>
+    Below that is a list of all the annotators.  Clicking on an annotator will show the list of their measurements and the next series they would be told to measure.
+    </p>
+    <p>
+    Note that some screenshot links are dead if they are for measurements added before the screenshot feature existed.
+    </p>
+
+    <div id='stats'>
+      <h2 id='bySeries'>Count of measurements by series id</h2>
+
+      <h3 id='seriesMeasurements'>Measurements of selected series</h3>
+
+      <h2 id='byAnnotator'>Count of measurements by annotator</h2>
+
+      <h3 id='annotatorMeasurements'>Measurements of selected annotator</h3>
+    </div>
+
+  </head>
+  <body>
+
+    <script type="text/javascript" src="../node_modules/jquery/dist/jquery.min.js"></script>
+    <script type="text/javascript" src="../node_modules/pouchdb/dist/pouchdb.min.js"></script>
+    <script type="text/javascript" src="../node_modules/pouchdb/dist/pouchdb.find.min.js"></script>
+
+    <script type="text/javascript">
+
+    $(document).ready(function() {
+      const baseURL='http://rsnacrowdquant.cloudapp.net:5984';
+      const measurementsURL = `${baseURL}/measurements`;
+      const measurementsDB = new PouchDB(measurementsURL);
+      const chronicleURL = `${baseURL}/chronicle`;
+      const chronicleDB = new PouchDB(chronicleURL);
+
+      // first, get populate the current stats
+      updateStatsDisplay();
+
+      // then watch the database for changes and update the display when needed
+      var progressFeed = measurementsDB.changes({
+        since: 'now',
+        live: true,
+        include_docs: true
+      }).on('change', function(change) {
+        updateStatsDisplay();
+      }).on('complete', function(info) {
+        // changes() was canceled
+      }).on('error', function (err) {
+        console.error(err);
+      });
+
+      // pick a series with the least measurements that this user hasn't measured yet
+      // calls callback with seriesUID
+      function addNextSeriesForAnnotator(annoatorID, callback) {
+
+        // first, get list of all series (this should be factored out to be global and only queried once)
+        chronicleDB.query('instances/context', {
+          reduce: true,
+          group: true,
+          group_level: 3,
+        }).then(function (result) {
+          let seriesUIDs = [];
+          result.rows.forEach(row => {
+            seriesUIDs.push(row.key[2][2]);
+          });
+
+          // then get the list of all measurements per series and how many measurements
+          // (not all series will have been measured)
+          let measurementsPerSeries = {};
+          measurementsDB.query('by/seriesUID', {
+            reduce: true,
+            group: true,
+            level: 'exact',
+          }).then(function (result) {
+            result.rows.forEach(row => {
+              measurementsPerSeries[row.key] = row.value;
+            });
+
+            measurementsDB.query('by/annotators', {
+              reduce: false,
+              include_docs: true,
+              start_key: annoatorID,
+              end_key: annoatorID,
+            }).then(function (result) {
+              let annotatorMeasuredSeries = {}
+              result.rows.forEach(row => {
+                annotatorMeasuredSeries[row.doc.seriesUID] = true;
+              });
+
+              // now reconcile the data
+              // - look through each available series
+              // -- if nobody has measured it then use it
+              // - if the user already measured it, ignore it
+              // - otherwise find the least measured one
+              let leastMeasured = {seriesUID: undefined, measurementCount: Number.MAX_SAFE_INTEGER};
+              for (let seriesIndex = 0; seriesIndex < seriesUIDs.length; seriesIndex++) {
+                let seriesUID = seriesUIDs[seriesIndex];
+                if ( ! (seriesUID in measurementsPerSeries) ) {
+                  callback(seriesUID);
+                  return;
+                }
+                if ( (! (seriesUID in annotatorMeasuredSeries)) &&
+                      (measurementsPerSeries[seriesUID] < leastMeasured.measurementCount) ) {
+                  leastMeasured.seriesUID = seriesUID;
+                  leastMeasured.measurementCount = measurementsPerSeries[seriesUID];
+                }
+              }
+              callback(leastMeasured.seriesUID);
+
+            }).catch(function (err) {
+              alert('Could not fetch detailed statistics');
+              console.error(err);
+            });
+
+
+          }).catch(function (err) {
+            alert('Could not fetch statistics');
+            console.error(err);
+          });
+
+        }).catch('error', function (err) {
+          console.error(err);
+        });
+
+      }
+
+      function updateStatsDisplay() {
+        $('#stats p').remove();
+
+        measurementsDB.query('by/seriesUID', {
+          reduce: true,
+          group: true,
+          level: 'exact',
+        }).then(function (result) {
+          result.rows.forEach(row => {
+            $('#bySeries').after(`<p id="${row.key}">${row.key} ${row.value}</p>`);
+            $(`[id="${row.key}"]`).click(event => {
+              $('.seriesMeasurement').remove();
+              measurementsDB.query('by/seriesUID', {
+                reduce: false,
+                include_docs: true,
+                start_key: event.target.id,
+                end_key: event.target.id,
+              }).then(function (result) {
+                result.rows.forEach(row => {
+                  $('#seriesMeasurements').after(`
+                    <div class='seriesMeasurement'>
+                      <p>Annotator: ${row.doc.annotator}</p>
+                      <p>Length: ${row.doc.length}</p>
+                      <a href='${measurementsURL}/${row.id}/screenshot.png'>screenshot</a>
+                    </div>
+                  `);
+                });
+              }).catch(function (err) {
+                alert('Could not fetch detailed statistics');
+                console.error(err);
+              });
+            });
+          });
+        }).catch(function (err) {
+          alert('Could not fetch statistics');
+          console.error(err);
+        });
+
+        measurementsDB.query('by/annotators', {
+          reduce: true,
+          group: true,
+          level: 'exact',
+        }).then(function (result) {
+          result.rows.forEach(row => {
+            let annotatorID = row.key;
+            $('#byAnnotator').after(`<p id="${annotatorID}">${annotatorID} ${row.value}</p>`);
+            $(`#${annotatorID}`).click(event => {
+              // show next series for this annotator
+              $(`#${annotatorID}`).append(" Next series: ");
+              addNextSeriesForAnnotator(row.key, function(seriesUID) {
+                $(`#${annotatorID}`).append(seriesUID);
+              });
+              // show existing measurements for this annotator
+              $('.annotatorMeasurement').remove();
+              measurementsDB.query('by/annotators', {
+                reduce: false,
+                include_docs: true,
+                start_key: event.target.id,
+                end_key: event.target.id,
+              }).then(function (result) {
+                result.rows.forEach(row => {
+                  $('#annotatorMeasurements').after(`
+                    <div class='annotatorMeasurement'>
+                      <p>${annotatorID} for Series: ${row.doc.seriesUID}</p>
+                      <p>Length: ${row.doc.length}</p>
+                      <a href='${measurementsURL}/${row.id}/screenshot.png' target='_blank'>screenshot</a>
+                    </div>
+                  `);
+                });
+              }).catch(function (err) {
+                alert('Could not fetch detailed statistics');
+                console.error(err);
+              });
+            });
+          });
+        }).catch(function (err) {
+          alert('Could not fetch statistics');
+          console.error(err);
+        });
+      }
+    });
+
+/*
+  Development notes:
+
+
+These statistics use the map/reduce (non-mango query) style of access to couchdb
+so that we can easily get counts of the number of measurements per series.
+
+This design document was added manually using the fauxton interface:
+
+{
+  "_id": "_design/by",
+  "_rev": "2-3919f002c347f490133ba58fd9f9b327",
+  "views": {
+    "annotators": {
+      "reduce": "_count",
+      "map": "function (doc) {\n  emit(doc.annotator, 1);\n}"
+    },
+    "seriesUID": {
+      "reduce": "_count",
+      "map": "function (doc) {\n  emit(doc.seriesUID, 1);\n}"
+    }
+  },
+  "language": "javascript"
+}
+
+Here's an example URL to test access to the view:
+
+http://rsnacrowdquant.cloudapp.net:5984//measurements/_design/by/_view/seriesUID?reduce=true&group=true
+
+
+
+Note it is also possible to directly access to view of mango index for map/reduce, but not used in the code above.
+
+http://rsnacrowdquant.cloudapp.net:5984/measurements/_design/d72bdb9e558e0db519b0643e2ffc05108d379d56/_view/annotator?include_docs=true&reduce=false
+
+http://rsnacrowdquant.cloudapp.net:5984/measurements/_design/d72bdb9e558e0db519b0643e2ffc05108d379d56/_view/annotator?include_docs=true&reduce=false&start_key=[%22shocked_pony%22]&end_key=[%22shocked_pony%22]
+
+http://rsnacrowdquant.cloudapp.net:5984/measurements/_design/d72bdb9e558e0db519b0643e2ffc05108d379d56/_view/annotator?reduce=true&level=2
+
+*/
+
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Uses measurements database and chronicle to do
the following:

* get number list of series that have measurements
along with a count of the number of measurements

* get the list of measurement documents for a given series

* get the list of annotators and the count of series
they have annotated

* get the list of measurements for a given annotator

* get the next suggested series for a given annotator,
such that the series is one that the annotator has not
already measured and that has the fewest (or zero) measurements
in the series list.