### PR TITLE
More gracefully handle end of series

### DIFF
--- a/src/viewer/files.js
+++ b/src/viewer/files.js
@@ -120,6 +120,11 @@ export default {
       this.seriesUID_A = seriesUID;
       console.log('series UID:', seriesUID);
 
+      if (seriesUID === undefined) {
+        alert('Congratulations - you have looked at all the series');
+        window.location.reload();
+      }
+
       return chronicleDB.query("instances/seriesInstances", {
         startkey : seriesUID,
         endkey : seriesUID + '\u9999',


### PR DESCRIPTION
Before seriesUID would be undefined when all cases have been
rated (or skipped) and that led to a never ending spinner and
lots of database timeout errors in the console.

Now the user is booted back to the login screen and if desired
can log in with a new account.